### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -2,6 +2,8 @@
 # https://github.com/firebase/firebase-tools
 
 name: Deploy to Firebase Hosting on merge
+permissions:
+  contents: read
 'on':
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/CubedCard/scaling-computing-machine/security/code-scanning/8](https://github.com/CubedCard/scaling-computing-machine/security/code-scanning/8)

To fix the problem, add a `permissions` block to the workflow to explicitly set the least privilege required for the `GITHUB_TOKEN`. The minimal starting point is `contents: read`, which allows the workflow to read repository contents but not write to them. This block can be added at the workflow level (top-level, after `name:` and before `on:`) or at the job level (inside the `build_and_deploy` job). Since the workflow only checks out code and deploys to Firebase, `contents: read` is likely sufficient. If the workflow later requires more permissions (e.g., to update pull requests), the block can be adjusted accordingly.

**Change to make:**  
- Add the following block after the `name:` line and before the `on:` block:
  ```yaml
  permissions:
    contents: read
  ```
- No new imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
